### PR TITLE
packaging 22.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "21.3" %}
+{% set version = "22.0" %}
 
 package:
   name: packaging
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/packaging/packaging-{{ version }}.tar.gz
-  sha256: dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb
+  sha256: 2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,27 +10,25 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
-  noarch: python
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
 
   host:
     - python
+    - flit-core
     - pip
-    - setuptools >=40.8.0
+    - setuptools
     - wheel
   run:
-    - python >=3.6
-    - pyparsing >=2.0.2,!=3.0.5
+    - python
 
 test:
   imports:
     - packaging
   requires:
     - pip
-    - python <3.10
   commands:
     - pip check
 
@@ -41,7 +39,7 @@ about:
   license_file: LICENSE
   license_family: Apache
   summary: Core utilities for Python packages
-  doc_url: https://packaging.pypa.io/en/latest/
+  doc_url: https://packaging.pypa.io
   dev_url: https://github.com/pypa/packaging
   doc_source_url: https://github.com/pypa/packaging/tree/master/docs
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ about:
   summary: Core utilities for Python packages
   doc_url: https://packaging.pypa.io
   dev_url: https://github.com/pypa/packaging
-  doc_source_url: https://github.com/pypa/packaging/tree/master/docs
+  doc_source_url: https://github.com/pypa/packaging/tree/main/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
-
   host:
     - python
     - flit-core


### PR DESCRIPTION
**Jira ticket:** [PKG-922](https://anaconda.atlassian.net/browse/PKG-922) (packaging 22.0)

**The upstream data:**
Github releases:  https://github.com/pypa/packaging/releases
[Diff between the latest and previous upstream releases](https://github.com/pypa/packaging/compare/21.3...22.0)
Changelog: https://github.com/pypa/packaging/blob/main/CHANGELOG.rst
Requirements:
 * pyproject.toml:  https://github.com/pypa/packaging/blob/22.0/pyproject.toml

**_Actions:_**

1. Remove `noarch python`
2. Skip `py<37`
3. Add `flit-core` to host
4. Remove `pyparsing >=2.0.2,!=3.0.5` from `run`
5. Fix `python` in `run`
6. Remove `python <3.10` from t`est/requires`
7. Update `doc_url`


**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 22.0
 * Release on PyPi:
    * version: 22.0
    * date: 2022-12-07T23:18:13
* [PyPi history](https://pypi.org/project/packaging/#history)
 * Popularity: 
    * 3 months downloads: 3950580.0
    * All time:  23661263 downloads -  packaging  22.0  Core utilities for Python packages  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/pypa/packaging/tree/22.0 exists
8. - [x] The upstream url:
    https://github.com/pypa/packaging
    
9. - [x] Check the pinnings
10. - [x] Additional research
    https://github.com/pypa/packaging/issues
11. - [x] `dev_url` error:
    https://github.com/pypa/packaging
12. - [x] Verify that the `build_number` is correct
13. - [x] has `setuptools`
14. - [x] has `wheel`
15. - [x] `pip` in test
16. - [x] Verify the test section
17. - [x] Verify if the package is `architecture specific`
18. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
19.  - [x] license_file: LICENSE is present

20. - [x] license_family Apache is present
21. - [x] License: Apache-2.0
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier   |
|:-------------|
| Apache-2.0   |
</details>

**Package Build Score: 19**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/packaging-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/packaging-feedstock/tree/22.0)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/packaging)
* [Diff between upstream and feature branch](https://github.com/conda-forge/packaging-feedstock/compare/main...AnacondaRecipes:22.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/packaging-feedstock/compare/master...AnacondaRecipes:22.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/packaging-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 22.0 git@github.com:AnacondaRecipes/packaging-feedstock.git
```
