### PR TITLE
packaging 23.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "22.0" %}
+{% set version = "23.0" %}
 
 package:
   name: packaging
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/packaging/packaging-{{ version }}.tar.gz
-  sha256: 2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3
+  sha256: b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97
 
 build:
   number: 0


### PR DESCRIPTION
**The upstream data:**
Github releases:  https://github.com/pypa/packaging/releases
[Diff between the latest and previous upstream releases](https://github.com/pypa/packaging/compare/22.0...23.0)
Changelog: https://github.com/pypa/packaging/blob/main/CHANGELOG.rst
Requirements:
 * pyproject.toml:  https://github.com/pypa/packaging/blob/23.0/pyproject.toml

**_Actions:_**

1. No changes


**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 23.0
 * Release on PyPi:
    * version: 23.0
    * date: 2023-01-08T18:18:54
* [PyPi history](https://pypi.org/project/packaging/#history)
 * Popularity: 
    * 3 months downloads: 3548299.0
    * All time:  26140936 downloads -  packaging  23.0  Core utilities for Python packages  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
5. - [x] has `wheel`
7. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE is present

14. - [x] license_family Apache is present
16. - [x] License: Apache-2.0
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier   |
|:-------------|
| Apache-2.0   |
</details>

**Check dependency issues:**

<details>
../aggregate/packaging-feedstock/recipe/meta.yaml
Dependencies: ['setuptools', 'python', 'pip', 'wheel', 'flit-core']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 19**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/packaging-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/packaging-feedstock/tree/23.0)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/packaging)
* [Diff between upstream and feature branch](https://github.com/conda-forge/packaging-feedstock/compare/main...AnacondaRecipes:23.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/packaging-feedstock/compare/master...AnacondaRecipes:23.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/packaging-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 23.0 git@github.com:AnacondaRecipes/packaging-feedstock.git
```
