### PR TITLE
packaging 25.0: Rebuild for py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
-pbp_autopublish: true
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/pretend-feedstock/pr2/b07d20f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/pretend-feedstock/pr2/b07d20f

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- []()
- [Upstream repo](https://github.com/pypa/packaging/tree/25.0)
- release-notes: https://github.com/pypa/packaging/releases
- release-notes-tagged: https://github.com/pypa/packaging/releases/tag/25.0
- changelog: https://github.com/pypa/packaging/blob/main/CHANGELOG.rst
- requirements-tagged: https://github.com/pypa/packaging/blob/25.0/pyproject.toml


### Explanation of changes:

- Bump a build number to 1
- Add `ANACONDA_ROCKET_ENABLE_PY314 : yes` to `abs.yaml`